### PR TITLE
Use direnv to setup virtualenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+layout python python2
+pip install --quiet -r requirements.txt
+watch_file requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 html/
+.direnv

--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ Review and run the `bootstrap.sh` script to generate the EPUB.
 
 **Note**: Currently relies on python2 and pip to install dependencies
 and does not setup a virtualenv. Please review the script and edit
-as per your needs.
+as per your needs. If you have [direnv](https://direnv.net/)
+installed, it will set up the virtualenv for you after you run
+`direnv allow`.


### PR DESCRIPTION
[direnv](https://direnv.net/) will automatically setup a virtualenv and handle the pip install. Running the pip install in bootstrap.sh will become a no-op