### PR TITLE
Adding missing Requirement on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Requirements:
 - Ruby
 - gem install bundler
 - gem install nokogiri
+- brew install pandoc
 - brew cask install calibre
 
 # Known Issues


### PR DESCRIPTION
It seems pandoc is missing on the Requirements list. 