### PR TITLE
Add support for building eBook with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:17.10
+FROM ubuntu:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:17.10
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    calibre \
+    pandoc \
+    ruby \
+    ruby-dev \
+    wget \
+    zlib1g-dev
+
+RUN gem install bundler --no-ri --no-rdoc
+
+COPY . /
+
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Generates a EPUB/MOBI for the Google SRE Book.
 
 Original sources are downloaded from https://landing.google.com/sre/
 
+# Build
+
+## macOS
+
 Review and run the `bootstrap.sh` script to generate the EPUB and MOBI files
 
 Requirements:
@@ -16,6 +20,16 @@ Requirements:
 - brew install pandoc
 - brew cask install calibre
 - brew install wget
+
+## Docker
+
+Requirements:
+
+- Docker
+
+```
+$ ./build_docker.sh
+```
 
 # Known Issues
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,6 @@ bundle install
 ruby generate.rb
 
 pushd html/chapters
-pandoc -f html+smart -t epub+smart -o ../../google-sre.epub --epub-metadata=../../metadata.xml --epub-cover-image=../../cover.jpg sre.html
+pandoc -f html -t epub -o ../../google-sre.epub --epub-metadata=../../metadata.xml --epub-cover-image=../../cover.jpg sre.html
 popd
 ebook-convert google-sre.epub google-sre.mobi

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+docker build -t google-sre-ebook .
+docker run -i --rm -v "$(pwd):/output" google-sre-ebook sh -s <<EOF
+./bootstrap.sh
+chown -v $(id -u):$(id -g) /google-sre.*
+mv -f /google-sre.* /output
+EOF


### PR DESCRIPTION
This change adds support for building the eBook with Docker. Supporting Docker means
that users who want to build the eBook do not have to install Ruby/Bundler/Calibre in their
environments.

I'm a Docker n00b, so if there's a better way to handle file permissions on the output, I'm all
ears.

Build tested on Linux. Outputs were fine.

There is also a change to the pandoc outputs. It seems the `+smart` extension is not supported for epub/html[0] in their latest versions.

Big thanks to @captn3m0 for creating this repo!

[0] - https://pandoc.org/MANUAL.html#extension-smart