### PR TITLE
Fix the missing table of content

### DIFF
--- a/generate.rb
+++ b/generate.rb
@@ -11,7 +11,11 @@ html = ''
 chapter_links.each do |chapter_link|
   chapter_file = File.basename chapter_link
   html += "<span class=\"hidden\" name=\"#{chapter_file}\"></span>"
-  content = Nokogiri::HTML(open("html/#{chapter_link}")).css('.content')
+  doc = Nokogiri::HTML(open("html/#{chapter_link}"))
+  content = doc.css('.content')
+
+  # this title is with additional 'chapter X' in front
+  title = doc.at_css('h2.chapter-title').content
 
   content.css('.cont').each do |e|
     e.remove
@@ -56,6 +60,19 @@ chapter_links.each do |chapter_link|
       end
     end
   end
+
+  if content.children.css('section > h1').length > 0
+    # remove additional parent section tag
+    content = content.children.at_css('section')
+  elsif content.children.css('div > h1').length > 0
+    # remove additional parent div tag
+    content = content.children.at_css('div')
+  else
+    content
+  end
+
+  # replace h1 title
+  content.at_css('h1').inner_html = title
 
   html += content.inner_html
 end

--- a/generate.rb
+++ b/generate.rb
@@ -67,8 +67,6 @@ chapter_links.each do |chapter_link|
   elsif content.children.css('div > h1').length > 0
     # remove additional parent div tag
     content = content.children.at_css('div')
-  else
-    content
   end
 
   # replace h1 title


### PR DESCRIPTION
Hi Nemo,

I noticed that when running your version against the latest google sre book website some titles in the table of content are missing.

You can compare here:

Before:
<img width="396" alt="screen shot 2018-08-02 at 11 13 06 pm" src="https://user-images.githubusercontent.com/87769/43585956-b79e22f8-96a9-11e8-8860-c1a38ee9830a.png">

After:
<img width="392" alt="screen shot 2018-08-02 at 11 13 17 pm" src="https://user-images.githubusercontent.com/87769/43585964-bbc591a4-96a9-11e8-86a3-01a7e2011e69.png">

Regards,
Wei