### PR TITLE
Update README command to use Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ docker run --rm --volume "$(pwd):/output" -e BOOK_SLUG='srw_book' captn3m0/goo
 ```
 $ mkdir /tmp/sreoutput
 $ chcon -Rt svirt_sandbox_file_t /tmp/sreoutput
-$ docker run --rm --volume "/tmp/sreoutput:/output" -e BOOK_SLUG='srw_book' ghcr.io/captn3m0/google-sre-ebook:ruby
+$ docker run --rm --volume "/tmp/sreoutput:/output" -e BOOK_SLUG='srw_book' captn3m0/google-sre-ebook:latest
 ```
 
 Builds on [Docker Hub](https://hub.docker.com/r/captn3m0/google-sre-ebook) are no longer maintained.


### PR DESCRIPTION
The instructions had a reference to an image hosted on GitHub Container Registry, however that image either doesn't exist or is not publicly accessible. It is also not accessible when authenticated with a GitHub Personal Access Token. The image is available on Docker Hub so this commit updates the command to use Docker Hub as the registry.